### PR TITLE
Remove thinking message on new message

### DIFF
--- a/codeaide/ui/chat_window.py
+++ b/codeaide/ui/chat_window.py
@@ -176,6 +176,7 @@ class ChatWindow(QMainWindow):
 
     def handle_response(self, response):
         self.enable_ui_elements()
+        self.remove_thinking_messages()
 
         if response["type"] == "message":
             self.add_to_chat("AI", response["message"])


### PR DESCRIPTION
At some point I inadvertently broke functionality that was removing the thinking message when an API response was received. This PR reinstates that behavior.