### PR TITLE
Make model provider selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
 
 CodeAIde is an AI-powered coding assistant that helps developers write, test, and optimize code through natural language interactions. By leveraging the power of large language models, CodeAIde aims to streamline the coding process and boost productivity.
 
+This is designed to be a simple, intuitive tool for writing, running, and refining simple Python scripts. It is not meant to be a full IDE or code editing environment and isn't a replacement for a tool like Cursor or Github Copilot. Instead, it is intended to be a simple tool for quickly writing code and getting it working without the need to worry about setting up environments, installing dependencies, etc.
+
 ## Features
 
 - Natural language code generation
+- Support for OpenAI and Anthropic APIs
 - Interactive clarification process for precise code output
+- Version control for generated code
 - Local code execution and testing
 - Cost tracking for API usage (not yet implemented)
 
 ## Examples
 
-Here are some example videos demonstrating use. Example prompts can be accessed by clicking "Use Example" and selecting from avaialable examples.
+Here are some example videos demonstrating use. Example prompts can be accessed by clicking "Use Example" and selecting from available examples.
 
 First, a simple matplotlib plot with followup requests to modify aesthetics.  
 

--- a/codeaide/utils/api_utils.py
+++ b/codeaide/utils/api_utils.py
@@ -155,7 +155,7 @@ def check_api_connection():
         response = client.messages.create(
             model=DEFAULT_MODEL,
             max_tokens=100,
-            messages=[{"role": "user", "content": "Hi Claude, are we communicating?"}],
+            messages=[{"role": "user", "content": "Are we communicating?"}],
         )
         return True, response.content[0].text.strip()
     except Exception as e:

--- a/codeaide/utils/constants.py
+++ b/codeaide/utils/constants.py
@@ -1,7 +1,29 @@
 # API Configuration
-MAX_TOKENS = 8192  # This is the maximum token limit for the API
-AI_MODEL = "claude-3-5-sonnet-20240620"
-MAX_RETRIES = 3  # Maximum number of retries for API requests (in case of errors or responses that can't be parsed)
+AI_PROVIDERS = {
+    "anthropic": {
+        "api_key_name": "ANTHROPIC_API_KEY",
+        "models": {
+            "claude-3-opus-20240229": {"max_tokens": 8192},
+            "claude-3-5-sonnet-20240620": {"max_tokens": 8192},
+            "claude-3-haiku-20240307": {"max_tokens": 4096},
+        },
+    },
+    "openai": {
+        "api_key_name": "OPENAI_API_KEY",
+        "models": {
+            "gpt-4": {"max_tokens": 8192},
+            "gpt-4-32k": {"max_tokens": 32768},
+            "gpt-3.5-turbo": {"max_tokens": 4096},
+        },
+    },
+}
+
+# Default model (we'll keep this for backwards compatibility)
+DEFAULT_MODEL = "claude-3-haiku-20240307"  # "claude-3-5-sonnet-20240620"
+DEFAULT_PROVIDER = "anthropic"
+
+# Other existing constants remain unchanged
+MAX_RETRIES = 3
 
 # UI Configuration
 CHAT_WINDOW_WIDTH = 800

--- a/codeaide/utils/constants.py
+++ b/codeaide/utils/constants.py
@@ -3,7 +3,7 @@ AI_PROVIDERS = {
     "anthropic": {
         "api_key_name": "ANTHROPIC_API_KEY",
         "models": {
-            "claude-3-opus-20240229": {"max_tokens": 8192},
+            "claude-3-opus-20240229": {"max_tokens": 4096},
             "claude-3-5-sonnet-20240620": {"max_tokens": 8192},
             "claude-3-haiku-20240307": {"max_tokens": 4096},
         },
@@ -11,8 +11,10 @@ AI_PROVIDERS = {
     "openai": {
         "api_key_name": "OPENAI_API_KEY",
         "models": {
-            "gpt-4": {"max_tokens": 8192},
-            "gpt-4-32k": {"max_tokens": 32768},
+            "chatgpt-4o-latest": {"max_tokens": 16384},
+            "gpt-4o-mini": {"max_tokens": 16384},
+            "o1-preview": {"max_tokens": 32768},
+            "gpt-4-turbo": {"max_tokens": 4096},
             "gpt-3.5-turbo": {"max_tokens": 4096},
         },
     },

--- a/codeaide/utils/constants.py
+++ b/codeaide/utils/constants.py
@@ -11,17 +11,16 @@ AI_PROVIDERS = {
     "openai": {
         "api_key_name": "OPENAI_API_KEY",
         "models": {
+            "gpt-3.5-turbo": {"max_tokens": 4096},
+            "gpt-4-turbo": {"max_tokens": 4096},
             "chatgpt-4o-latest": {"max_tokens": 16384},
             "gpt-4o-mini": {"max_tokens": 16384},
-            "o1-preview": {"max_tokens": 32768},
-            "gpt-4-turbo": {"max_tokens": 4096},
-            "gpt-3.5-turbo": {"max_tokens": 4096},
         },
     },
 }
 
-# Default model (we'll keep this for backwards compatibility)
-DEFAULT_MODEL = "claude-3-haiku-20240307"  # "claude-3-5-sonnet-20240620"
+# Default model
+DEFAULT_MODEL = "claude-3-5-sonnet-20240620"
 DEFAULT_PROVIDER = "anthropic"
 
 # Other existing constants remain unchanged

--- a/codeaide/utils/cost_tracker.py
+++ b/codeaide/utils/cost_tracker.py
@@ -7,30 +7,10 @@ class CostTracker:
         self.cost_per_1k_tokens = 0.03  # Update this with actual pricing
 
     def log_request(self, response):
-        # The new API doesn't provide direct access to prompt tokens
-        # We'll estimate based on the response tokens
-        completion_tokens = response.usage.output_tokens
-        # Estimate prompt tokens (this is not accurate, but it's a rough estimate)
-        estimated_prompt_tokens = completion_tokens // 2
-        total_tokens = estimated_prompt_tokens + completion_tokens
-        estimated_cost = (total_tokens / 1000) * self.cost_per_1k_tokens
-
-        self.cost_log.append(
-            {
-                "timestamp": datetime.now(),
-                "estimated_prompt_tokens": estimated_prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": total_tokens,
-                "estimated_cost": estimated_cost,
-            }
-        )
+        pass
 
     def get_total_cost(self):
-        return sum(entry["estimated_cost"] for entry in self.cost_log)
+        return 0
 
     def print_summary(self):
-        total_cost = self.get_total_cost()
-        total_tokens = sum(entry["total_tokens"] for entry in self.cost_log)
-        print(f"\nTotal estimated cost: ${total_cost:.4f}")
-        print(f"Total tokens used: {total_tokens}")
-        print(f"Number of API calls: {len(self.cost_log)}")
+        print("Cost summary not implemented")

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ markers =
     send_api_request: marks tests related to sending API requests
     parse_response: marks tests related to parsing API responses
     api_connection: marks tests related to API connection
+    integration: mark a test as an integration test that uses actual API keys
+addopts = -m "not integration"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 anthropic==0.34.2
 python-decouple==3.8
 virtualenv==20.16.2
+google-generativeai
+hjson
 pyyaml
 pytest
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 anthropic==0.34.2
 python-decouple==3.8
 virtualenv==20.16.2
-google-generativeai
+openai
 hjson
 pyyaml
 pytest

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -1,0 +1,130 @@
+"""
+This file contains integration tests for the API functionality of the CodeAide application.
+
+These tests verify the correct operation of API clients, request sending, and response parsing
+for both Anthropic and OpenAI APIs. They ensure that the application can successfully
+communicate with these external services and handle their responses appropriately.
+
+IMPORTANT: These tests use live API calls and will incur charges on your API accounts.
+They are designed to complement the existing unit tests and are not part of the
+continuous integration pipeline. These tests should be run manually and infrequently,
+primarily to verify that the API functionality is working as expected with the live APIs.
+
+To run these tests:
+1. Ensure you have the necessary API keys set in your environment variables:
+   - ANTHROPIC_API_KEY for Anthropic tests
+   - OPENAI_API_KEY for OpenAI tests
+2. Install pytest if not already installed: `pip install pytest`
+3. Navigate to the project root directory
+4. Run the tests using the command: `pytest -m integration`
+
+Note: These tests are marked with the 'integration' marker and are specifically run
+using the `-m integration` flag. This allows them to be easily separated from other
+tests and run independently when needed.
+
+Caution: Due to the use of live API calls, these tests should not be run frequently
+or as part of automated CI/CD processes to avoid unnecessary API charges.
+"""
+
+import pytest
+from codeaide.utils.api_utils import get_api_client, send_api_request, parse_response
+from codeaide.utils.constants import SYSTEM_PROMPT
+
+ANTHROPIC_MODEL = "claude-3-haiku-20240307"
+OPENAI_MODEL = "gpt-3.5-turbo"
+
+MINIMAL_PROMPT = """
+Please respond with a JSON object containing the following fields:
+- text: A brief description of the code.
+- code: A piece of code that prints "Hello, World!".
+- code_version: The version of the code.
+- version_description: A brief description of the version.
+- requirements: An empty list.
+- questions: An empty list.
+"""
+
+
+@pytest.mark.integration
+def test_anthropic_api():
+    """
+    Integration test for the Anthropic API.
+
+    This test:
+    1. Initializes the Anthropic API client
+    2. Sends a request to the API with a minimal prompt
+    3. Verifies that a non-empty response is received
+    4. Checks that the response contains the word "Hello"
+    5. Attempts to parse the response
+    6. Verifies that all expected fields are present in the parsed response
+    """
+    api_client = get_api_client(provider="anthropic")
+    assert api_client is not None, "Anthropic API client initialization failed"
+
+    conversation_history = [{"role": "user", "content": MINIMAL_PROMPT}]
+    response = send_api_request(
+        api_client, conversation_history, 100, ANTHROPIC_MODEL, "anthropic"
+    )
+    assert response is not None, "Anthropic API request failed"
+    assert "Hello" in response.content[0].text, "Unexpected response from Anthropic API"
+
+    # Test parse_response function
+    parsed_response = parse_response(response, "anthropic")
+    assert parsed_response is not None, "Failed to parse response from Anthropic API"
+    (
+        text,
+        questions,
+        code,
+        code_version,
+        version_description,
+        requirements,
+    ) = parsed_response
+    assert text is not None, "Parsed text is None"
+    assert isinstance(questions, list), "Parsed questions is not a list"
+    assert code is not None, "Parsed code is None"
+    assert code_version is not None, "Parsed code_version is None"
+    assert version_description is not None, "Parsed version_description is None"
+    assert isinstance(requirements, list), "Parsed requirements is not a list"
+
+
+@pytest.mark.integration
+def test_openai_api():
+    """
+    Integration test for the OpenAI API.
+
+    This test:
+    1. Initializes the OpenAI API client
+    2. Sends a request to the API with a minimal prompt
+    3. Verifies that a non-empty response is received
+    4. Checks that the response contains the word "Hello"
+    5. Attempts to parse the response
+    6. Verifies that all expected fields are present in the parsed response
+    """
+    api_client = get_api_client(provider="openai")
+    assert api_client is not None, "OpenAI API client initialization failed"
+
+    conversation_history = [{"role": "user", "content": MINIMAL_PROMPT}]
+    response = send_api_request(
+        api_client, conversation_history, 100, OPENAI_MODEL, "openai"
+    )
+    assert response is not None, "OpenAI API request failed"
+    assert (
+        "Hello" in response.choices[0].message.content
+    ), "Unexpected response from OpenAI API"
+
+    # Test parse_response function
+    parsed_response = parse_response(response, "openai")
+    assert parsed_response is not None, "Failed to parse response from OpenAI API"
+    (
+        text,
+        questions,
+        code,
+        code_version,
+        version_description,
+        requirements,
+    ) = parsed_response
+    assert text is not None, "Parsed text is None"
+    assert isinstance(questions, list), "Parsed questions is not a list"
+    assert code is not None, "Parsed code is None"
+    assert code_version is not None, "Parsed code_version is None"
+    assert version_description is not None, "Parsed version_description is None"
+    assert isinstance(requirements, list), "Parsed requirements is not a list"


### PR DESCRIPTION
Allows user to choose openai or anthropic models. 

Adds to tests to exercise both API formats with mock fixtures

Adds an integration test that generates minimal responses from the live APIs.