### PR TITLE
Add logic for clearing and starting new session

### DIFF
--- a/codeaide/logic/chat_handler.py
+++ b/codeaide/logic/chat_handler.py
@@ -22,7 +22,10 @@ from codeaide.utils.environment_manager import EnvironmentManager
 from codeaide.utils.file_handler import FileHandler
 from codeaide.utils.terminal_manager import TerminalManager
 from codeaide.utils.general_utils import generate_session_id
-from codeaide.utils.logging_config import get_logger
+from codeaide.utils.logging_config import get_logger, setup_logger
+from PyQt5.QtWidgets import QMessageBox
+
+logger = get_logger()
 
 
 class ChatHandler:
@@ -529,3 +532,36 @@ class ChatHandler:
 
     def set_latest_version(self, version):
         self.latest_version = version
+
+    def start_new_session(self, chat_window):
+        logger.info("Starting new session")
+
+        # Generate new session ID
+        new_session_id = generate_session_id()
+
+        # Create new FileHandler with new session ID
+        new_file_handler = FileHandler(session_id=new_session_id)
+
+        # Copy existing log to new session and set up new logger
+        self.file_handler.copy_log_to_new_session(new_session_id)
+        setup_logger(new_file_handler.session_dir)
+
+        # Update instance variables
+        self.session_id = new_session_id
+        self.file_handler = new_file_handler
+
+        # Clear conversation history
+        self.conversation_history = []
+
+        # Clear chat display in UI
+        chat_window.clear_chat_display()
+
+        # Close code pop-up if it exists
+        chat_window.close_code_popup()
+
+        # Show confirmation message
+        QMessageBox.information(
+            chat_window, "New Session", "A new session has been started."
+        )
+
+        logger.info(f"New session started with ID: {self.session_id}")

--- a/codeaide/logic/chat_handler.py
+++ b/codeaide/logic/chat_handler.py
@@ -575,3 +575,15 @@ class ChatHandler:
 
         logger.info(f"New session started with ID: {self.session_id}")
         logger.info(f"New session directory: {self.session_dir}")
+
+    # New method to load a previous session
+    def load_previous_session(self, session_id, chat_window):
+        logger.info(f"Loading previous session: {session_id}")
+        self.session_id = session_id
+        self.file_handler = FileHandler(session_id=session_id)
+        self.session_dir = self.file_handler.session_dir
+
+        # Load chat contents
+        chat_window.load_chat_contents()
+
+        logger.info(f"Loaded previous session with ID: {self.session_id}")

--- a/codeaide/logic/chat_handler.py
+++ b/codeaide/logic/chat_handler.py
@@ -16,6 +16,7 @@ from codeaide.utils.constants import (
     AI_PROVIDERS,
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
+    INITIAL_MESSAGE,
 )
 from codeaide.utils.cost_tracker import CostTracker
 from codeaide.utils.environment_manager import EnvironmentManager
@@ -42,6 +43,9 @@ class ChatHandler:
         self.session_id = generate_session_id()
         self.cost_tracker = CostTracker()
         self.file_handler = FileHandler(session_id=self.session_id)
+        self.session_dir = (
+            self.file_handler.session_dir
+        )  # Store the specific session directory
         self.logger = get_logger()
         self.conversation_history = self.file_handler.load_chat_history()
         self.env_manager = EnvironmentManager()
@@ -57,6 +61,7 @@ class ChatHandler:
 
         self.api_key_valid, self.api_key_message = self.check_api_key()
         self.logger.info(f"New session started with ID: {self.session_id}")
+        self.logger.info(f"Session directory: {self.session_dir}")
 
     def check_api_key(self):
         """
@@ -536,6 +541,9 @@ class ChatHandler:
     def start_new_session(self, chat_window):
         logger.info("Starting new session")
 
+        # Log the previous session path correctly
+        logger.info(f"Previous session path: {self.session_dir}")
+
         # Generate new session ID
         new_session_id = generate_session_id()
 
@@ -549,6 +557,7 @@ class ChatHandler:
         # Update instance variables
         self.session_id = new_session_id
         self.file_handler = new_file_handler
+        self.session_dir = new_file_handler.session_dir  # Update the session directory
 
         # Clear conversation history
         self.conversation_history = []
@@ -559,9 +568,10 @@ class ChatHandler:
         # Close code pop-up if it exists
         chat_window.close_code_popup()
 
-        # Show confirmation message
-        QMessageBox.information(
-            chat_window, "New Session", "A new session has been started."
-        )
+        # Add system message about previous session
+        system_message = f"A new session has been started. The previous chat will not be visible to the agent. Previous session data saved in: {self.session_dir}"
+        chat_window.add_to_chat("System", system_message)
+        chat_window.add_to_chat("AI", INITIAL_MESSAGE)
 
         logger.info(f"New session started with ID: {self.session_id}")
+        logger.info(f"New session directory: {self.session_dir}")

--- a/codeaide/ui/chat_window.py
+++ b/codeaide/ui/chat_window.py
@@ -133,14 +133,13 @@ class ChatWindow(QMainWindow):
         self.example_button.clicked.connect(self.load_example)
         button_layout.addWidget(self.example_button)
 
-        self.exit_button = QPushButton("Exit", self)
-        self.exit_button.clicked.connect(self.on_exit)
-        button_layout.addWidget(self.exit_button)
-
-        # Add New Session button
         self.new_session_button = QPushButton("New Session")
         self.new_session_button.clicked.connect(self.on_new_session_clicked)
         button_layout.addWidget(self.new_session_button)
+
+        self.exit_button = QPushButton("Exit", self)
+        self.exit_button.clicked.connect(self.on_exit)
+        button_layout.addWidget(self.exit_button)
 
         main_layout.addLayout(button_layout)
 
@@ -351,7 +350,7 @@ class ChatWindow(QMainWindow):
         self.add_to_chat("System", switch_message)
 
     def on_new_session_clicked(self):
-        logger.info("User clicked New Session button")
+        self.logger.info("User clicked New Session button")
         reply = QMessageBox.question(
             self,
             "New Session",
@@ -361,17 +360,17 @@ class ChatWindow(QMainWindow):
         )
 
         if reply == QMessageBox.Yes:
-            logger.info("User confirmed starting a new session")
+            self.logger.info("User confirmed starting a new session")
             self.chat_handler.start_new_session(self)
         else:
-            logger.info("User cancelled starting a new session")
+            self.logger.info("User cancelled starting a new session")
 
     def clear_chat_display(self):
         self.chat_display.clear()
-        logger.info("Cleared chat display in UI")
+        self.logger.info("Cleared chat display in UI")
 
     def close_code_popup(self):
         if self.code_popup:
             self.code_popup.close()
             self.code_popup = None
-            logger.info("Closed code pop-up")
+            self.logger.info("Closed code pop-up")

--- a/codeaide/ui/chat_window.py
+++ b/codeaide/ui/chat_window.py
@@ -137,6 +137,11 @@ class ChatWindow(QMainWindow):
         self.exit_button.clicked.connect(self.on_exit)
         button_layout.addWidget(self.exit_button)
 
+        # Add New Session button
+        self.new_session_button = QPushButton("New Session")
+        self.new_session_button.clicked.connect(self.on_new_session_clicked)
+        button_layout.addWidget(self.new_session_button)
+
         main_layout.addLayout(button_layout)
 
         self.logger.info("Chat window UI initialized")
@@ -344,3 +349,29 @@ class ChatWindow(QMainWindow):
         )
 
         self.add_to_chat("System", switch_message)
+
+    def on_new_session_clicked(self):
+        logger.info("User clicked New Session button")
+        reply = QMessageBox.question(
+            self,
+            "New Session",
+            "This will start a new session with a new chat history. Are you sure you'd like to proceed?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+
+        if reply == QMessageBox.Yes:
+            logger.info("User confirmed starting a new session")
+            self.chat_handler.start_new_session(self)
+        else:
+            logger.info("User cancelled starting a new session")
+
+    def clear_chat_display(self):
+        self.chat_display.clear()
+        logger.info("Cleared chat display in UI")
+
+    def close_code_popup(self):
+        if self.code_popup:
+            self.code_popup.close()
+            self.code_popup = None
+            logger.info("Closed code pop-up")

--- a/codeaide/ui/chat_window.py
+++ b/codeaide/ui/chat_window.py
@@ -51,6 +51,7 @@ class ChatWindow(QMainWindow):
         self.cost_tracker = getattr(chat_handler, "cost_tracker", None)
         self.code_popup = None
         self.waiting_for_api_key = False
+        self.chat_contents = []
         self.setup_ui()
 
         # Check API key status
@@ -202,7 +203,15 @@ class ChatWindow(QMainWindow):
         self.chat_display.append(html_message + "<br>")
         self.chat_display.ensureCursorVisible()
 
-        self.logger.debug(f"Adding message to chat from {sender}: {message}")
+        self.logger.debug(
+            f"Adding message to chat from {sender}: {message}"
+        )  # Log first 50 chars
+
+        # Add message to chat contents
+        self.chat_contents.append({"sender": sender, "message": message})
+
+        # Save chat contents
+        self.chat_handler.file_handler.save_chat_contents(self.chat_contents)
 
     def display_thinking(self):
         self.add_to_chat("AI", "Thinking... 🤔")
@@ -367,10 +376,18 @@ class ChatWindow(QMainWindow):
 
     def clear_chat_display(self):
         self.chat_display.clear()
-        self.logger.info("Cleared chat display in UI")
+        self.chat_contents = []
+        self.chat_handler.file_handler.save_chat_contents(self.chat_contents)
+        self.logger.info("Cleared chat display and contents in UI")
 
     def close_code_popup(self):
         if self.code_popup:
             self.code_popup.close()
             self.code_popup = None
             self.logger.info("Closed code pop-up")
+
+    def load_chat_contents(self):
+        self.chat_contents = self.chat_handler.file_handler.load_chat_contents()
+        for item in self.chat_contents:
+            self.add_to_chat(item["sender"], item["message"])
+        self.logger.info(f"Loaded {len(self.chat_contents)} messages from chat log")

--- a/codeaide/utils/file_handler.py
+++ b/codeaide/utils/file_handler.py
@@ -24,6 +24,11 @@ class FileHandler:
             if self.session_dir
             else None
         )
+        self.chat_window_log_file = (
+            os.path.join(self.session_dir, "chat_window_log.json")
+            if self.session_dir
+            else None
+        )
         self._ensure_output_dirs_exist()
 
         if self.session_dir:
@@ -115,6 +120,30 @@ class FileHandler:
                 return json.load(f)
         except Exception as e:
             self.logger.error(f"Error loading chat history: {str(e)}")
+            return []
+
+    def save_chat_contents(self, chat_contents):
+        if not self.session_dir:
+            self.logger.error("Session directory not set. Cannot save chat contents.")
+            return
+
+        try:
+            with open(self.chat_window_log_file, "w", encoding="utf-8") as f:
+                json.dump(chat_contents, f, ensure_ascii=False, indent=2)
+            self.logger.info(f"Chat contents saved to {self.chat_window_log_file}")
+        except Exception as e:
+            self.logger.error(f"Error saving chat contents: {str(e)}")
+
+    def load_chat_contents(self):
+        if not os.path.exists(self.chat_window_log_file):
+            self.logger.info(f"No chat log file found at {self.chat_window_log_file}")
+            return []
+
+        try:
+            with open(self.chat_window_log_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as e:
+            self.logger.error(f"Error loading chat contents: {str(e)}")
             return []
 
     def set_session_id(self, session_id):

--- a/codeaide/utils/file_handler.py
+++ b/codeaide/utils/file_handler.py
@@ -124,3 +124,25 @@ class FileHandler:
         self._ensure_output_dirs_exist()
         setup_logger(self.session_dir)
         self.logger = get_logger()
+
+    def copy_log_to_new_session(self, new_session_id):
+        new_session_dir = os.path.join(self.output_dir, new_session_id)
+        os.makedirs(new_session_dir, exist_ok=True)
+
+        old_log_file = os.path.join(self.session_dir, "codeaide.log")
+        new_log_file = os.path.join(new_session_dir, "codeaide.log")
+
+        os.makedirs(os.path.dirname(new_log_file), exist_ok=True)
+
+        if os.path.exists(old_log_file):
+            shutil.copy2(old_log_file, new_log_file)
+
+            # Append a message to the old log file
+            with open(old_log_file, "a") as f:
+                f.write("\nNew session created. Log continued in new file.\n")
+
+            self.logger.info(f"Copied log file to new session: {new_session_id}")
+        else:
+            self.logger.warning(
+                f"No existing log file found to copy for new session: {new_session_id}"
+            )


### PR DESCRIPTION
Adds a button to clear the session. Clears the chat window and the chat history. Starts a new session. This is useful if we want to eliminate the previous chat from the context to save tokens.

Also saves the full chat window history to a file in the session_data folder to facilitate a future feature that would allow us to continue from existing sessions.